### PR TITLE
feat: add container image

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,47 @@
+# Container build ignore file
+# Reduces build context size and prevents sensitive files from being included
+
+# Git
+.git/
+.gitignore
+
+# Build artifacts
+target/
+*.jar
+*.class
+
+# IDE files
+.idea/
+*.iml
+.vscode/
+.settings/
+.project
+.classpath
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+log/
+
+# Documentation (not needed in container)
+*.md
+!README.md
+how_to_build.txt
+
+# Build tools (used for alternative build, not container)
+tools/
+build.js
+definitions.xml
+deploy.sh
+
+# Test files (tests run in CI, not in container build)
+src/test/
+
+# Container files themselves
+Containerfile
+Dockerfile
+.containerignore
+.dockerignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - master
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: kairosdb/kafka-monitor
+
+jobs:
+  test:
+    name: Test & Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run tests
+        run: mvn verify -B
+
+  build-and-push:
+    name: Build & Push Image
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build image
+        uses: redhat-actions/buildah-build@v2
+        id: build
+        with:
+          containerfiles: ./Containerfile
+          image: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64, linux/arm64/v8
+
+      - name: Push to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          image: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,83 @@
+# syntax=docker/dockerfile:1.7
+# Containerfile for Kafka Topic Monitor
+
+# Build stage
+
+# NOTE: it would be better to use -alpine variant for a smaller image, but
+# Java 17 builds are not available for all architectures. Switch after
+# upgrading Java version to 21 or above (here & runtime).
+FROM docker.io/library/maven:3-eclipse-temurin-17 AS builder
+
+WORKDIR /build
+
+# Cache dependencies
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
+# Build the application (skip tests for faster builds, run tests in CI)
+COPY src/ src/
+RUN mvn package -DskipTests -B \
+    # Verify the JAR was created
+    && test -f target/kafka-topic-monitor-*.jar \
+    # Rename to predictable name for runtime stage
+    && cp target/kafka-topic-monitor-*.jar target/kafka-topic-monitor.jar
+
+# Runtime stage
+
+FROM docker.io/library/eclipse-temurin:17-jre AS runtime
+
+# Labels for container metadata (OCI standard)
+LABEL org.opencontainers.image.title="Kafka Topic Monitor" \
+      org.opencontainers.image.description="Monitors Kafka consumer lag and reports metrics via metrics4j" \
+      org.opencontainers.image.vendor="KairosDB" \
+      org.opencontainers.image.source="https://github.com/kairosdb/kafka-monitor" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# Use non-root user and group for security, use fixed UID/GID for reproducibility
+# and Kubernetes security contexts
+ARG APP_UID=10001
+ARG APP_GID=10001
+
+RUN addgroup --gid ${APP_GID} --system appgroup \
+    && adduser --uid ${APP_UID} --system --ingroup appgroup --home /app --shell /sbin/nologin appuser
+
+WORKDIR /app
+
+COPY --from=builder --chown=appuser:appgroup \
+    /build/target/kafka-topic-monitor.jar \
+    /app/kafka-topic-monitor.jar
+
+COPY --chown=appuser:appgroup conf/ /app/conf/
+
+#RUN apk --no-cache upgrade \
+#    && rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists /var/cache/apt/*
+
+
+USER appuser:appgroup
+
+# Environment variables for JVM tuning in containers
+# These can be overridden at runtime
+ENV JAVA_CONTAINER_OPTS="-XX:+UseContainerSupport \
+    -XX:MaxRAMPercentage=75.0 \
+    -XX:InitialRAMPercentage=50.0 \
+    -XX:+ExitOnOutOfMemoryError"
+
+# Application configuration via environment variables
+ENV METRICS4J_CONFIG=/app/conf/metrics4j.conf \
+    LOGBACK_CONFIG=/app/conf/logback-container.xml
+ENV JAVA_APP_OPTS="-DMETRICS4J_CONFIG=${METRICS4J_CONFIG} \
+    -Dlogback.configurationFile=${LOGBACK_CONFIG}"
+ENV JAVA_ARGS=""
+
+# Expose default Jooby port
+EXPOSE 8080
+
+ENTRYPOINT [ \
+    "sh", \
+    "-c", \
+    "exec java ${JAVA_CONTAINER_OPTS} ${JAVA_APP_OPTS} ${JAVA_ARGS} -jar /app/kafka-topic-monitor.jar $*" \
+]

--- a/README.md
+++ b/README.md
@@ -25,5 +25,18 @@ the following command line
 The project is packaged with stork.  Calling `mvn package` will create a complete
 install directory under target/stork
 
+A container image can be built using the Containerfile in this directory, for
+example:
+
+```sh
+# podman
+podman image build -t kafka-topic-monitor:latest .
+
+# docker
+docker build -t kafka-topic-monitor:latest -f Containerfile .
+```
+
+Pre-built images are available at https://hub.docker.com/r/kairosdb/kafka-monitor
+
 ## Configuration
 All configuration is done in application.conf see the comments in the file for details

--- a/conf/logback-container.xml
+++ b/conf/logback-container.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="false">
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>[%d{ISO8601}]-[%thread] %-5level %logger - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
Add container image build manifest (Containerfile), and a GitHub Actions workflow to automatically build that image and push it to Docker Hub.

This will make it easier to use the application on K8s, etc.